### PR TITLE
Undefined linker extention violation

### DIFF
--- a/native-maven-plugin/src/main/java/org/codehaus/mojo/natives/plugin/NativeLinkMojo.java
+++ b/native-maven-plugin/src/main/java/org/codehaus/mojo/natives/plugin/NativeLinkMojo.java
@@ -141,7 +141,6 @@ public class NativeLinkMojo
      * artifact is used.
      *
      * @parameter default-value=""
-     * @required
      * @since 1.0-alpha-9
      */
     private String linkerFinalNameExt;

--- a/native-maven-plugin/src/test/java/org/codehaus/mojo/natives/plugin/NativeLinkerMojoTest.java
+++ b/native-maven-plugin/src/test/java/org/codehaus/mojo/natives/plugin/NativeLinkerMojoTest.java
@@ -43,7 +43,7 @@ public class NativeLinkerMojoTest
         Artifact artifact = new DefaultArtifact( "test", "test", VersionRange.createFromVersion( "1.0-SNAPSHOT" ), "compile", "exe", null, artifactHandler);
         mojo.getProject().setArtifact( artifact );
 
-        // simulate artifactss
+        // simulate artifacts
         mojo.getProject().setArtifacts( new HashSet() ); // no extern libs for now
 
         String linkerFinalName = "some-final-name";

--- a/native-maven-plugin/src/test/java/org/codehaus/mojo/natives/plugin/NativeLinkerMojoTest.java
+++ b/native-maven-plugin/src/test/java/org/codehaus/mojo/natives/plugin/NativeLinkerMojoTest.java
@@ -27,8 +27,7 @@ public class NativeLinkerMojoTest
         return mojo;
     }
 
-    public void testExecute()
-        throws Exception
+    public void testExecute() throws Exception
     {
         NativeLinkMojo mojo = getMojo();
 
@@ -41,12 +40,10 @@ public class NativeLinkerMojoTest
         // simulate artifact
         ArtifactHandler artifactHandler = new DefaultArtifactHandler();
 
-        Artifact artifact =
-            new DefaultArtifact( "test", "test", VersionRange.createFromVersion( "1.0-SNAPSHOT" ), "compile", "exe",
-                                 null, artifactHandler );
+        Artifact artifact = new DefaultArtifact( "test", "test", VersionRange.createFromVersion( "1.0-SNAPSHOT" ), "compile", "exe", null, artifactHandler);
         mojo.getProject().setArtifact( artifact );
 
-        // simulate artifacts
+        // simulate artifactss
         mojo.getProject().setArtifacts( new HashSet() ); // no extern libs for now
 
         String linkerFinalName = "some-final-name";
@@ -59,13 +56,13 @@ public class NativeLinkerMojoTest
         // "target is set in the stub
         assertEquals( new File( "target" ), conf.getOutputDirectory() );
         assertEquals( linkerFinalName, conf.getOutputFileName() );
+        assertNull(conf.getOutputFileExtension() );
         // current artifactHandler mocking return null extension name
         assertEquals( new File( "target/some-final-name.null" ), conf.getOutputFile() );
 
     }
 
-    public void testExecuteWithFinalNameExtension()
-            throws Exception
+    public void testExecuteWithFinalNameExtension() throws Exception
     {
         NativeLinkMojo mojo = getMojo();
 
@@ -78,9 +75,7 @@ public class NativeLinkerMojoTest
         // simulate artifact
         ArtifactHandler artifactHandler = new DefaultArtifactHandler();
 
-        Artifact artifact =
-                new DefaultArtifact( "test", "test", VersionRange.createFromVersion( "1.0-SNAPSHOT" ), "compile", "exe",
-                        null, artifactHandler );
+        Artifact artifact = new DefaultArtifact( "test", "test", VersionRange.createFromVersion( "1.0-SNAPSHOT" ), "compile", "exe", null, artifactHandler );
         mojo.getProject().setArtifact( artifact );
 
         // simulate artifacts


### PR DESCRIPTION
This pull request adress an issue when linkerFinalNameExt is undefined (and expecting to use the project packaging type). 
In the current version, linkerFinalNameExt  is required, but if it is not defined, native-maven-plugin should use the packaging type of the POM and not die due to the mojo model validation rules violation.

Below, an extract of Maven failure :
```
Failed to execute goal org.codehaus.mojo:native-maven-plugin:1.0-alpha-9-SNAPSHOT:link (default-link) on project phobos: The parameters 'linkerFinalNameExt' for goal org.codehaus.mojo:native-maven-plugin:1.0-alpha-9-SNAPSHOT:link are missing or invalid -> [Help 1]
```
With this patch, if linkerFinalNameExt not provided, native-maven-plugin use the current packaging type : 
```
--- native-maven-plugin:1.0-alpha-9-SNAPSHOT:link (default-link) @ phobos ---
cmd.exe /X /C "gcc -s -o D:\NetBeansProjects\BitBucket\hall\natives\phobos\target\phobos.exe target\phobos.res target\objs\cmdline.obj target\objs\console.obj target\objs\handles.obj target\objs\javajni.obj target\objs\log.obj target\objs\mclib.obj target\objs\phobos.obj target\objs\registry.obj target\objs\rprocess.obj target\objs\service.obj target\objs\utils.obj"

--- native-maven-plugin:1.0-alpha-9-SNAPSHOT:manifest (default-manifest) @ phobos ---

--- maven-resources-plugin:3.0.1:testResources (default-testResources) @ phobos ---
Using platform encoding (Cp1252 actually) to copy filtered resources, i.e. build is platform dependent!
skip non existing resourceDirectory D:\NetBeansProjects\BitBucket\hall\natives\phobos\src\test\resources

--- maven-compiler-plugin:3.5.1:testCompile (default-testCompile) @ phobos ---
No sources to compile

--- maven-surefire-plugin:2.19.1:test (default-test) @ phobos ---

--- maven-install-plugin:2.5.2:install (default-install) @ phobos ---
Installing D:\NetBeansProjects\BitBucket\hall\natives\phobos\target\phobos.exe to C:\Users\gchauvet\.m2\repository\io\zatarox\hall\phobos\1.0.0-SNAPSHOT\phobos-1.0.0-SNAPSHOT.exe
Installing D:\NetBeansProjects\BitBucket\hall\natives\phobos\pom.xml to C:\Users\gchauvet\.m2\repository\io\zatarox\hall\phobos\1.0.0-SNAPSHOT\phobos-1.0.0-SNAPSHOT.pom
------------------------------------------------------------------------
```
