### PR TITLE
Update plexus-archiver dependency, as the old version fails when dete…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-archiver</artifactId>
-        <version>2.6.3</version>
+        <version>3.5</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
…cting java version under Java10.

Stacktrace to avoid:
java.lang.ArrayIndexOutOfBoundsException: 1
    at org.codehaus.plexus.archiver.zip.AbstractZipArchiver.<clinit> (AbstractZipArchiver.java:113)
    at org.codehaus.mojo.natives.plugin.NativeBundleIncludeFilesMojo.execute (NativeBundleIncludeFilesMojo.java:85)

The problem is caused by the "new" Java versioning scheme and it was solved in https://github.com/codehaus-plexus/plexus-archiver/commit/c0357c5234fedb958bc2dd93a8397424bdcea7cf#diff-fc3ccce5d0e801c14a494428ab189152