### PR TITLE
Clear the compiler outputs after linking

### DIFF
--- a/native-maven-plugin/src/main/java/org/codehaus/mojo/natives/plugin/NativeLinkMojo.java
+++ b/native-maven-plugin/src/main/java/org/codehaus/mojo/natives/plugin/NativeLinkMojo.java
@@ -215,6 +215,7 @@ public class NativeLinkMojo
             List<File> allCompilerOuputFiles = this.getAllCompilersOutputFileList();
 
             File outputFile = linker.link( config, allCompilerOuputFiles );
+            allCompilerOuputFiles.clear();
 
             // to be used by post linker mojo like native:manifest
             @SuppressWarnings({ "unused", "unchecked" })


### PR DESCRIPTION
Clear the compiler outputs after linking, so the next execution doesn…'t get the objects that have already been linked.

This fixes #26 